### PR TITLE
Switch from warning to python logging

### DIFF
--- a/pyaxmlparser/arscparser.py
+++ b/pyaxmlparser/arscparser.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from pyaxmlparser import bytecode
 import collections
 from struct import unpack
@@ -24,7 +25,8 @@ from pyaxmlparser.stringblock import StringBlock
 import pyaxmlparser.constants as const
 from pyaxmlparser.utils import complexToFloat
 from xml.sax.saxutils import escape
-from warnings import warn
+
+log = logging.getLogger("pyaxmlparser.arscparser")
 
 
 class ARSCParser(object):
@@ -102,7 +104,7 @@ class ARSCParser(object):
                 # Read all other headers
                 while self.buff.get_idx() <= package_data_end - ARSCHeader.SIZE:
                     pkg_chunk_header = ARSCHeader(self.buff)
-                    warn("Found a header: {}".format(pkg_chunk_header))
+                    log.debug("Found a header: {}".format(pkg_chunk_header))
                     if pkg_chunk_header.start + pkg_chunk_header.size > package_data_end:
                         # we are way off the package chunk; bail out
                         break
@@ -117,7 +119,7 @@ class ARSCParser(object):
                         self.packages[package_name].append(a_res_type)
                         self.resource_configs[package_name][a_res_type].add(a_res_type.config)
 
-                        warn("Config: {}".format(a_res_type.config))
+                        log.debug("Config: {}".format(a_res_type.config))
 
                         entries = []
                         for i in range(0, a_res_type.entryCount):
@@ -143,7 +145,7 @@ class ARSCParser(object):
                                     # Not sure if this is a good solution though
                                     self.buff.set_idx(ate.start)
                     elif pkg_chunk_header.type == const.RES_TABLE_LIBRARY_TYPE:
-                        warn("RES_TABLE_LIBRARY_TYPE chunk is not supported")
+                        log.warning("RES_TABLE_LIBRARY_TYPE chunk is not supported")
                     else:
                         # silently skip other chunk types
                         pass
@@ -274,7 +276,7 @@ class ARSCParser(object):
                     const.DIMENSION_UNITS[ate.key.get_data() & const.COMPLEX_UNIT_MASK])
             ]
         except IndexError:
-            warn("Out of range dimension unit index for %s: %s" % (
+            log.warning("Out of range dimension unit index for %s: %s" % (
                 complexToFloat(ate.key.get_data()),
                 ate.key.get_data() & const.COMPLEX_UNIT_MASK))
             return [ate.get_value(), ate.key.get_data()]
@@ -630,7 +632,7 @@ given result.
             raise ValueError("'rid' must be an int")
 
         if rid not in self.resource_values:
-            warn("The requested rid could not be found in the resources.")
+            log.warning("The requested rid could not be found in the resources.")
             return []
 
         res_options = self.resource_values[rid]
@@ -638,7 +640,7 @@ given result.
             if config in res_options:
                 return [(config, res_options[config])]
             elif fallback and config == ARSCResTableConfig.default_config():
-                warn("No default resource config could be found for the given rid, using fallback!")
+                log.warning("No default resource config could be found for the given rid, using fallback!")
                 return [list(self.resource_values[rid].items())[0]]
             else:
                 return []

--- a/pyaxmlparser/arscutil.py
+++ b/pyaxmlparser/arscutil.py
@@ -15,10 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from struct import unpack
-from warnings import warn
 import pyaxmlparser.constants as const
 from pyaxmlparser.utils import format_value
+
+log = logging.getLogger("pyaxmlparser.arscutil")
 
 
 class ARSCResTablePackage(object):
@@ -178,7 +180,7 @@ class ARSCResTableConfig(object):
 
             self.exceedingSize = self.size - 36
             if self.exceedingSize > 0:
-                warn("Skipping padding bytes!")
+                log.debug("Skipping padding bytes!")
                 self.padding = buff.read(self.exceedingSize)
 
         # TODO there is screenConfig2

--- a/pyaxmlparser/core.py
+++ b/pyaxmlparser/core.py
@@ -1,8 +1,12 @@
+
+import logging
 from pyaxmlparser.arscparser import ARSCParser
 from pyaxmlparser.axmlprinter import AXMLPrinter
 from pyaxmlparser.arscutil import ARSCResTableConfig
 from pyaxmlparser.utils import get_zip_file, NS_ANDROID
-from warnings import warn
+
+
+log = logging.getLogger("pyaxmlparser.core")
 
 
 class APK:
@@ -132,7 +136,7 @@ class APK:
                     res_id,
                     ARSCResTableConfig.default_config())[0][1]
             except Exception as e:
-                warn("Exception selecting app name: %s" % e)
+                log.warning("Exception selecting app name: %s" % e)
                 app_name = self.package
         return app_name
 
@@ -154,7 +158,7 @@ class APK:
             hex_value = self.arsc.get_id(value, int(key, 0))[1]
             rsc = self.arsc.get_string(value, hex_value)[1]
         except Exception as e:
-            warn(str(e))
+            log.warning(str(e))
             rsc = None
         return rsc
 
@@ -222,7 +226,7 @@ class APK:
                         app_icon = file_name
                         current_dpi = dpi
             except Exception as e:
-                warn("Exception selecting app icon: %s" % e)
+                log.warning("Exception selecting app icon: %s" % e)
 
         return self.zip_file.read(app_icon)
 

--- a/pyaxmlparser/stringblock.py
+++ b/pyaxmlparser/stringblock.py
@@ -15,8 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from struct import unpack
-from warnings import warn
+
+
+log = logging.getLogger("pyaxmlparser.stringblock")
+
 
 # Flags in the STRING Section
 SORTED_FLAG = 1 << 0
@@ -51,7 +55,7 @@ class StringBlock(object):
 
         # Check if they supplied a stylesOffset even if the count is 0:
         if self.styleOffsetCount == 0 and self.stylesOffset > 0:
-            warn("Styles Offset given, but styleCount is zero.")
+            log.warning("Styles Offset given, but styleCount is zero.")
 
         self.m_stringOffsets = []
         self.m_styleOffsets = []
@@ -78,7 +82,7 @@ class StringBlock(object):
 
         # FIXME unaligned
         if (size % 4) != 0:
-            warn("Size of strings is not aligned by four bytes.")
+            log.warning("Size of strings is not aligned by four bytes.")
 
         self.m_charbuff = buff.read(size)
 
@@ -87,7 +91,7 @@ class StringBlock(object):
 
             # FIXME unaligned
             if (size % 4) != 0:
-                warn("Size of styles is not aligned by four bytes.")
+                log.warning("Size of styles is not aligned by four bytes.")
 
             for i in range(0, size // 4):
                 self.m_styles.append(unpack('<i', buff.read(4))[0])
@@ -137,7 +141,7 @@ class StringBlock(object):
     def decode_bytes(self, data, encoding, str_len):
         string = data.decode(encoding, 'replace')
         if len(string) != str_len:
-            warn("invalid decoded string length")
+            log.warning("invalid decoded string length")
         return string
 
     def decodeLength(self, offset, sizeof_char):


### PR DESCRIPTION
Switch from python `warning` to `logging`

This way the users can enable/disable warning output using the standard python logging module.

closes #19