### PR TITLE
Unset app_icon in the case of sym_def_app_icon

### DIFF
--- a/pyaxmlparser/core.py
+++ b/pyaxmlparser/core.py
@@ -9,6 +9,7 @@ from pyaxmlparser.arscparser import ARSCParser
 from pyaxmlparser.axmlprinter import AXMLPrinter
 from pyaxmlparser.axmlparser import AXMLParser
 from pyaxmlparser.arscutil import ARSCResTableConfig
+from pyaxmlparser.resources import public
 import pyaxmlparser.constants as const
 
 import io
@@ -377,6 +378,17 @@ class APK(object):
         if not res_parser:
             # Can not do anything below this point to resolve...
             return None
+
+        if app_icon.startswith("@android:"):
+            android_res_id = app_icon[9:]
+            # default icon:
+                # https://developer.android.com/reference/android/R.mipmap#sym_def_app_icon or
+                # https://developer.android.com/reference/android/R.drawable#sym_def_app_icon
+            if (
+                public.SYSTEM_RESOURCES['mipmaps']['inverse'].get(int(android_res_id, 16)) == 'sym_def_app_icon' or
+                public.SYSTEM_RESOURCES['drawables']['inverse'].get(int(android_res_id, 16)) == 'sym_def_app_icon'
+            ):
+                app_icon = None
 
         if not app_icon:
             res_id = res_parser.get_res_id_by_key(self.package, 'mipmap', 'ic_launcher')

--- a/pyaxmlparser/resources/public.py
+++ b/pyaxmlparser/resources/public.py
@@ -28,6 +28,14 @@ SYSTEM_RESOURCES = {
     "styles": {
         "forward": {k: v for k, v in _public_res['style'].items()},
         "inverse": {v: k for k, v in _public_res['style'].items()}
+    },
+    "drawables": {
+        "forward": {k: v for k, v in _public_res['drawable'].items()},
+        "inverse": {v: k for k, v in _public_res['drawable'].items()}
+    },
+    "mipmaps": {
+        "forward": {k: v for k, v in _public_res['mipmap'].items()},
+        "inverse": {v: k for k, v in _public_res['mipmap'].items()}
     }
 }
 


### PR DESCRIPTION
When the icon is set with default placeholder eg: `android:icon="@android:drawable/sym_def_app_icon"`, the `app_icon` value  calculated is `@android:01080093` 

So the below code fails:
https://github.com/appknox/pyaxmlparser/blob/042344d26e9f03b57d7964323e44fc0ec3ef92e0/pyaxmlparser/core.py#L395-L396 
```
ValueError: invalid literal for int() with base 16: 'android:01080093'
```

This PR bypasses setting `app_icon` for the 🔝  scenario inorder to use `ic_launcher` if it is defined in the app resources