### PR TITLE
Add apkinfo manpage

### DIFF
--- a/apkinfo.1
+++ b/apkinfo.1
@@ -1,0 +1,23 @@
+.\"
+.\" apkinfo(1)
+.\"
+.\" Copyright (C) 2018 Andres Salomon
+.TH apkinfo 1 "June 2018"
+.SH NAME
+apkinfo \- display information about an Android APK file
+.SH SYNOPSIS
+.B apkinfo
+[\fI\,OPTIONS\/\fR] \fI\,FILENAME\/\fR
+.SH OPTIONS
+.TP
+\fB\-\-help\fR
+Show a list of possible options and exit.
+.SH DESCRIPTION
+.B apkinfo
+is a tool to display information about a downloaded Android APK file.
+.B apkinfo
+displays APK metadata such as package, version, and naming information.
+
+This man page was contributed by Andres Salomon <dilinger@debian.org>
+for the Debian GNU/Linux system (but may be used by others).
+

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
 
     author='Subho Halder',
     author_email='sunny@appknox.com',
-    license='MIT',
+    license='Apache License 2.0',
 
     data_files=[('man/man1', ['apkinfo.1'])],
     packages=find_packages(exclude=['tests', 'examples']),
@@ -34,7 +34,7 @@ setup(
 
         'Intended Audience :: Developers',
 
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: Apache Software License',
 
         'Operating System :: POSIX',
         'Operating System :: MacOS',

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author_email='sunny@appknox.com',
     license='MIT',
 
+    data_files=[('man/man1', ['apkinfo.1'])],
     packages=find_packages(exclude=['tests', 'examples']),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
I maintain pyaxmlparser for Debian, and we've been carrying a man page for apkinfo for some time. I'd love to get this committed upstream.

While committing this, I realized that setup.py had the incorrect license, so I included a fix for that as well. Sorry for not doing a separate pull request, but I figure it's small enough that you wouldn't care.