### PR TITLE
Added fix for AXML parsing for invalid header

### DIFF
--- a/pyaxmlparser/axmlparser.py
+++ b/pyaxmlparser/axmlparser.py
@@ -235,8 +235,8 @@ class AXMLParser(object):
                     "At chunk type 0x{:04x}, declared header size={}, "
                     "chunk size={}".format(h.type, h.header_size, h.size)
                 )
-                self._valid = False
-                return
+                self.buff.seek(h.end)
+                continue
 
             # Line Number of the source file, only used as meta information
             self.m_lineNumber, = unpack('<L', self.buff.read(4))


### PR DESCRIPTION
Reference commit: https://github.com/androguard/androguard/commit/2f27cae53678559faec65e7c25e9d8fd0d730e3e
Fix for: https://github.com/androguard/androguard/issues/835